### PR TITLE
Enhancement/option support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.1.0"
+version = "0.2.0"
 
 authors = ["Rick <rickz75dev@gmail.com>", "Halfnelson <ewoudvanrooyen@gmail.com>"]
 description = "A bencode encoding/decoding implementation backed by serde."

--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ The types that are currently **not supported** are:
 * `f64`
 * `char`
 * `enum`
-* `Option<_>`
 
-Floats will never be supported, but `char`, `enum`, and `Option<_>` support will probably be added in the future.
+Floats will never be supported, but `char` and `enum` support will probably be added in the future.
 
 ## Contributing
 
@@ -74,5 +73,6 @@ Don't forget to give the project a star! Thanks again!
 
 ## Notes
 
+* Both variants of `Option<_>` (Some and None) are supported by the decoder, **but** the encoder only supports `Some`.
 * If you run into trouble encoding/decoding raw bytes, eg: `&[u8]` or `Vec<u8>` then use [this crate](https://crates.io/crates/serde_bytes).
 * The codebase is small (~1000 lines), easily digestible and filled with comments. If you're a first timer, you'll have a jolly time making your first contribution.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the library as a dependency to [Cargo.toml](https://doc.rust-lang.org/cargo/
 
 ```toml
 [dependencies]
-bende = "0.1.0"
+bende = "0.2.0"
 ```
 
 ### Example

--- a/src/de.rs
+++ b/src/de.rs
@@ -426,11 +426,11 @@ impl<'a, 'de> Deserializer<'de> for &'a mut Decoder<'de> {
         visitor.visit_byte_buf(self.decode_bytes()?.to_vec())
     }
 
-    fn deserialize_option<V>(self, _: V) -> Result<V::Value, Self::Error>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        Err(Error::Unsupported("Option<_>"))
+        visitor.visit_some(self)
     }
 
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -756,5 +756,35 @@ mod test {
             Decoder::new(b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe");
 
         assert_eq!(Person::deserialize(&mut de), Ok(jerry));
+    }
+
+    #[test]
+    fn deserialize_some() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        };
+
+        let mut de = Decoder::new(b"d4:name5:Jerry3:agei50ee");
+        assert_eq!(
+            Person::deserialize(&mut de),
+            Ok(Person { name: Some("Jerry".to_string()), age: 50 })
+        )
+    }
+
+    #[test]
+    fn deserialize_none() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        };
+
+        let mut de = Decoder::new(b"d3:agei50ee");
+        assert_eq!(
+            Person::deserialize(&mut de),
+            Ok(Person { name: None, age: 50 })
+        )
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -63,7 +63,11 @@ impl std::fmt::Display for Error {
                 expected, at, found
             ),
             Error::Unsupported(ref ty) => {
-                write!(f, "the type '{}' is not supported by the library", ty)
+                write!(
+                    f,
+                    "decoding of type '{}' is not supported by the library",
+                    ty
+                )
             }
             Error::Deserialize(ref e) => e.fmt(f),
             Error::Utf8(ref e) => e.fmt(f),

--- a/src/en.rs
+++ b/src/en.rs
@@ -212,7 +212,7 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(Error::Unsupported("Option<_>"))
+        Err(Error::Unsupported("None"))
     }
 
     fn serialize_some<T: ?Sized>(self, v: &T) -> Result<Self::Ok, Self::Error>

--- a/src/en.rs
+++ b/src/en.rs
@@ -519,6 +519,7 @@ mod test {
     use serde::Serialize;
 
     use super::Encoder;
+    use super::Error;
 
     #[test]
     fn encode_int_unsigned() {
@@ -587,5 +588,20 @@ mod test {
         let mut en = Encoder::new(vec![]);
         assert!(jerry.serialize(&mut en).is_ok());
         assert_eq!(en.buf, b"d4:name5:Jerry3:agei50ee".to_vec());
+    }
+
+    #[test]
+    #[should_panic]
+    fn serialize_none_err() {
+        #[derive(Debug, PartialEq, Serialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        };
+
+        let jerry = Person { name: None, age: 50 };
+
+        let mut en = Encoder::new(vec![]);
+        jerry.serialize(&mut en).unwrap();
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -573,4 +573,19 @@ mod test {
             b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe".to_vec()
         );
     }
+
+    #[test]
+    fn serialize_some() {
+        #[derive(Debug, PartialEq, Serialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        };
+
+        let jerry = Person { name: Some("Jerry".to_owned()), age: 50 };
+
+        let mut en = Encoder::new(vec![]);
+        assert!(jerry.serialize(&mut en).is_ok());
+        assert_eq!(en.buf, b"d4:name5:Jerry3:agei50ee".to_vec());
+    }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -41,7 +41,11 @@ impl std::fmt::Display for Error {
         match *self {
             Error::Io(ref e) => e.fmt(f),
             Error::Unsupported(ref ty) => {
-                write!(f, "the type '{}' is not supported by the library", ty)
+                write!(
+                    f,
+                    "encoding of type '{}' is not supported by the library",
+                    ty
+                )
             }
             Error::Serialize(ref e) => e.fmt(f),
         }

--- a/src/en.rs
+++ b/src/en.rs
@@ -215,11 +215,11 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
         Err(Error::Unsupported("Option<_>"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T: ?Sized>(self, v: &T) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
-        Err(Error::Unsupported("Option<_>"))
+        v.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,4 +162,23 @@ mod test {
         let bytes = encode(&armory).unwrap();
         assert_eq!(decode::<Armory>(&bytes).unwrap(), armory);
     }
+
+    #[test]
+    fn encode_and_decode_option() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Person {
+            name: Option<String>,
+            age: Option<u8>,
+            is_employed: Option<bool>,
+        }
+
+        let jerry = Person {
+            name: Some("Jerry Smith".to_string()),
+            age: Some(50),
+            is_employed: Some(false),
+        };
+
+        let bytes = encode(&jerry).unwrap();
+        assert_eq!(decode::<Person>(&bytes).unwrap(), jerry);
+    }
 }


### PR DESCRIPTION
Decoding support has been added for both variants of the `Option` type, namely `Some` and `None`.

Regarding encoding support:

For now, only the `Some` variant can be successfully encoded. This is a limitation of both bencode and serde, as there is no concept of `none` in the bencode format and there is no clear way to serialize `None` without also serializing the name of a field.

Consider this example:

```rust
struct Foo {
    bar: Option<i32>
}

let foo = Foo {
    bar: None
};

let _ = bende::encode(&foo)?;
```
The encoder will first serialize the field's name (bar) before moving to its value, meaning it will result in this:

```
d
    3:bar
    ...
e
```

This of course is not valid bencode syntax, as we are writing a key that maps to no value.

No obvious fix or work-around has become apparent to me, but if anyone else has any ideas, then by all means open a PR :)