### PR TITLE
Fix/units and newtypes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.2.0"
+version = "0.2.1"
 
 authors = ["Rick <rickz75dev@gmail.com>", "Halfnelson <ewoudvanrooyen@gmail.com>"]
 description = "A bencode encoding/decoding implementation backed by serde."

--- a/src/de.rs
+++ b/src/de.rs
@@ -803,4 +803,29 @@ mod test {
             Ok(Person { name: None, age: 50 })
         )
     }
+
+    #[test]
+    fn deserialize_unit_struct_ok() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Unit;
+
+        let mut de = Decoder::new(b"4:Unit");
+        assert_eq!(Unit::deserialize(&mut de), Ok(Unit));
+    }
+
+    #[test]
+    fn deserialize_unit_struct_err() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Unit;
+
+        let mut de = Decoder::new(b"3:Foo");
+        assert_eq!(
+            Unit::deserialize(&mut de),
+            Err(Error::Wanted {
+                at: 0,
+                expected: "Unit",
+                found: "Foo".to_string()
+            })
+        );
+    }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -828,4 +828,13 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn deserialize_newtype_struct() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Foo(i32);
+
+        let mut de = Decoder::new(b"i1995e");
+        assert_eq!(Foo::deserialize(&mut de), Ok(Foo(1995)));
+    }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -475,7 +475,7 @@ impl<'a, 'de> Deserializer<'de> for &'a mut Decoder<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_unit()
+        visitor.visit_newtype_struct(self)
     }
 
     // Sequences and tuple types are deserialized as a sequence.

--- a/src/en.rs
+++ b/src/en.rs
@@ -245,12 +245,12 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
     fn serialize_newtype_struct<T: ?Sized>(
         self,
         _: &'static str,
-        _: &T,
+        v: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
-        Ok(())
+        v.serialize(self)
     }
 
     fn serialize_newtype_variant<T: ?Sized>(

--- a/src/en.rs
+++ b/src/en.rs
@@ -228,9 +228,9 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
 
     fn serialize_unit_struct(
         self,
-        _: &'static str,
+        name: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Ok(())
+        self.serialize_str(name)
     }
 
     fn serialize_unit_variant(

--- a/src/en.rs
+++ b/src/en.rs
@@ -604,4 +604,14 @@ mod test {
         let mut en = Encoder::new(vec![]);
         jerry.serialize(&mut en).unwrap();
     }
+
+    #[test]
+    fn serialize_unit_struct() {
+        #[derive(Debug, Serialize)]
+        struct Unit;
+
+        let mut en = Encoder::new(vec![]);
+        Unit.serialize(&mut en).unwrap();
+        assert_eq!(en.buf, b"4:Unit".to_vec());
+    }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -614,4 +614,14 @@ mod test {
         Unit.serialize(&mut en).unwrap();
         assert_eq!(en.buf, b"4:Unit".to_vec());
     }
+
+    #[test]
+    fn serialize_newtype_struct() {
+        #[derive(Debug, Serialize)]
+        struct Foo(i32);
+
+        let mut en = Encoder::new(vec![]);
+        Foo(1995).serialize(&mut en).unwrap();
+        assert_eq!(en.buf, b"i1995e".to_vec());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,4 +190,15 @@ mod test {
         let bytes = encode(&Foo).unwrap();
         assert_eq!(decode::<Foo>(&bytes).unwrap(), Foo);
     }
+
+    #[test]
+    fn encode_and_decode_newtype_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Foo(i32);
+
+        let foo = Foo(1995);
+
+        let bytes = encode(&foo).unwrap();
+        assert_eq!(decode::<Foo>(&bytes), Ok(foo));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,4 +181,13 @@ mod test {
         let bytes = encode(&jerry).unwrap();
         assert_eq!(decode::<Person>(&bytes).unwrap(), jerry);
     }
+
+    #[test]
+    fn encode_and_decode_unit_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Foo;
+
+        let bytes = encode(&Foo).unwrap();
+        assert_eq!(decode::<Foo>(&bytes).unwrap(), Foo);
+    }
 }


### PR DESCRIPTION
I've added **proper** encoding and decoding support for unit structs (`Foo`) and new type structs (`Foo(T)`), alongside new tests.

I've also bumped the package version to `0.2.1`, because #2 considers that the previous implementation should be considered a bug.

Unit variants and new type variants will only be properly implemented **after** we've added `enum` support.