### PR TITLE
Fix/string only keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.2.1"
+version = "0.3.0"
 
 authors = ["Rick <rickz75dev@gmail.com>", "Halfnelson <ewoudvanrooyen@gmail.com>"]
 description = "A bencode encoding/decoding implementation backed by serde."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the library as a dependency to [Cargo.toml](https://doc.rust-lang.org/cargo/
 
 ```toml
 [dependencies]
-bende = "0.2.0"
+bende = "0.3.0"
 ```
 
 ### Example
@@ -74,5 +74,6 @@ Don't forget to give the project a star! Thanks again!
 ## Notes
 
 * Both variants of `Option<_>` (Some and None) are supported by the decoder, **but** the encoder only supports `Some`.
+* Keys in a key-value object must be strings, otherwise an error is returned.
 * If you run into trouble encoding/decoding raw bytes, eg: `&[u8]` or `Vec<u8>` then use [this crate](https://crates.io/crates/serde_bytes).
 * The codebase is small (~1000 lines), easily digestible and filled with comments. If you're a first timer, you'll have a jolly time making your first contribution.

--- a/src/de.rs
+++ b/src/de.rs
@@ -630,7 +630,8 @@ impl<'a, 'de> MapAccess<'de> for MapDecoder<'a, 'de> {
                 self.de.advance(1);
                 Ok(None)
             }
-            Some(_) => seed.deserialize(&mut *self.de).map(Some),
+            Some(b'0'..=b'9') => seed.deserialize(&mut *self.de).map(Some),
+            Some(_) => Err(Error::Malformed),
             _ => Err(Error::EOF),
         }
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -646,6 +646,8 @@ impl<'a, 'de> MapAccess<'de> for MapDecoder<'a, 'de> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use serde::Deserialize;
 
     use super::{Decoder, Error};
@@ -843,5 +845,23 @@ mod test {
 
         let mut de = Decoder::new(b"i1995e");
         assert_eq!(Foo::deserialize(&mut de), Ok(Foo(1995)));
+    }
+
+    #[test]
+    fn deserialize_map_ok() {
+        let mut map = HashMap::new();
+        map.insert("foo", "bar");
+
+        let mut de = Decoder::new(b"d3:foo3:bare");
+        assert_eq!(HashMap::deserialize(&mut de), Ok(map))
+    }
+
+    #[test]
+    fn deserialize_map_err() {
+        let mut de = Decoder::new(b"di1995e3:fooe");
+        assert_eq!(
+            HashMap::<i32, &str>::deserialize(&mut de),
+            Err(Error::Malformed)
+        )
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -3,6 +3,7 @@
 use std::io::Error as IoError;
 use std::io::Write;
 
+use serde::ser::Impossible;
 use serde::ser::SerializeMap;
 use serde::ser::SerializeSeq;
 use serde::ser::SerializeStruct;
@@ -532,6 +533,194 @@ impl<'a, W> KeyEncoder<'a, W> {
     #[inline]
     fn new(en: &'a mut Encoder<W>) -> KeyEncoder<'a, W> {
         Self { en }
+    }
+}
+
+impl<'a, W: Write> Serializer for KeyEncoder<'a, W> {
+    type Ok = ();
+
+    type Error = Error;
+
+    type SerializeSeq = Impossible<(), Error>;
+
+    type SerializeTuple = Impossible<(), Error>;
+
+    type SerializeTupleStruct = Impossible<(), Error>;
+
+    type SerializeTupleVariant = Impossible<(), Error>;
+
+    type SerializeMap = Impossible<(), Error>;
+
+    type SerializeStruct = Impossible<(), Error>;
+
+    type SerializeStructVariant = Impossible<(), Error>;
+
+    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.en.serialize_str(v)
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_unit_struct(
+        self,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_seq(
+        self,
+        _: Option<usize>,
+    ) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_tuple(
+        self,
+        _: usize,
+    ) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_map(
+        self,
+        _: Option<usize>,
+    ) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::InvalidKeyType)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::InvalidKeyType)
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -24,12 +24,15 @@ use super::TYPE_END;
 /// # Variants
 ///
 /// * `Io` - An I/O error from the standard library.
+/// * `InvalidKeyType` - When you try encoding a map with keys that are not of type string.
 /// * `Unsupported` - When you try encoding a type that is not currently supported by the library.
 /// * `Serialize` - A custom serde serialization error.
 #[derive(Debug)]
 pub enum Error {
     /// A standard I/O error.
     Io(IoError),
+    /// The encoder can only encode maps with keys that are of type string.
+    InvalidKeyType,
     /// Tried encoding a type that is not currently supported by the library.
     Unsupported(&'static str),
     /// A serde serialization error.
@@ -40,6 +43,10 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             Error::Io(ref e) => e.fmt(f),
+            Error::InvalidKeyType => write!(
+                f,
+                "encoder can only encode keys that are of type string"
+            ),
             Error::Unsupported(ref ty) => {
                 write!(
                     f,

--- a/src/en.rs
+++ b/src/en.rs
@@ -730,6 +730,7 @@ mod test {
 
     use super::Encoder;
     use super::Error;
+    use super::KeyEncoder;
 
     #[test]
     fn encode_int_unsigned() {
@@ -840,5 +841,27 @@ mod test {
         let mut en = Encoder::new(vec![]);
         Foo(1995).serialize(&mut en).unwrap();
         assert_eq!(en.buf, b"i1995e".to_vec());
+    }
+
+    #[test]
+    fn encode_key_ok() {
+        let mut parent = Encoder::new(vec![]);
+
+        let en = KeyEncoder::new(&mut parent);
+        assert!("foo".serialize(en).is_ok());
+
+        let en = KeyEncoder::new(&mut parent);
+        assert!("foo".to_string().serialize(en).is_ok());
+    }
+
+    #[test]
+    fn encode_key_err() {
+        let mut parent = Encoder::new(vec![]);
+
+        let mut en = KeyEncoder::new(&mut parent);
+        assert!((0i32).serialize(en).is_err());
+
+        let mut en = KeyEncoder::new(&mut parent);
+        assert!((true).serialize(en).is_err());
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -460,7 +460,7 @@ impl<'a, W: Write> SerializeMap for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
-        key.serialize(&mut *self.en)
+        key.serialize(KeyEncoder::new(self.en))
     }
 
     fn serialize_value<T: ?Sized>(

--- a/src/en.rs
+++ b/src/en.rs
@@ -527,6 +527,14 @@ struct KeyEncoder<'a, W> {
     en: &'a mut Encoder<W>,
 }
 
+impl<'a, W> KeyEncoder<'a, W> {
+    /// Constructs a new key encoder.
+    #[inline]
+    fn new(en: &'a mut Encoder<W>) -> KeyEncoder<'a, W> {
+        Self { en }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use serde::Serialize;

--- a/src/en.rs
+++ b/src/en.rs
@@ -726,6 +726,8 @@ impl<'a, W: Write> Serializer for KeyEncoder<'a, W> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use serde::Serialize;
 
     use super::Encoder;
@@ -863,5 +865,23 @@ mod test {
 
         let mut en = KeyEncoder::new(&mut parent);
         assert!((true).serialize(en).is_err());
+    }
+
+    #[test]
+    fn serialize_map_ok() {
+        let mut map = HashMap::new();
+        map.insert("foo", "bar");
+
+        let mut en = Encoder::new(vec![]);
+        assert!(map.serialize(&mut en).is_ok());
+    }
+
+    #[test]
+    fn serialize_map_err() {
+        let mut map = HashMap::new();
+        map.insert(0, "bar");
+
+        let mut en = Encoder::new(vec![]);
+        assert!(map.serialize(&mut en).is_err());
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -521,6 +521,12 @@ impl<'a, W: Write> SerializeStructVariant for MapEncoder<'a, W> {
     }
 }
 
+/// An encoder exclusively used to ensure that map keys are of type string before encoding them.
+#[derive(Debug)]
+struct KeyEncoder<'a, W> {
+    en: &'a mut Encoder<W>,
+}
+
 #[cfg(test)]
 mod test {
     use serde::Serialize;


### PR DESCRIPTION
An issue recently occurred to me. When encoding and decoding maps, the type of the keys is allowed to be **any type**. This of course is incorrect, because in bencode, dictionary keys must be of type string.

This pull request resolves this incorrect behavior by ensuring keys are of type string before encoding and decoding them.