### PR TITLE
Feat/sorted dict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.3.0"
+version = "0.4.0"
 
 authors = ["Rick <rickz75dev@gmail.com>", "Halfnelson <ewoudvanrooyen@gmail.com>"]
 description = "A bencode encoding/decoding implementation backed by serde."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Add the library as a dependency to [Cargo.toml](https://doc.rust-lang.org/cargo/
 
 ```toml
 [dependencies]
-bende = "0.3.0"
+bende = "0.4.0"
+serde = { version = "1", features = ["derive"] }
 ```
 
 ### Example
@@ -75,5 +76,6 @@ Don't forget to give the project a star! Thanks again!
 
 * Both variants of `Option<_>` (Some and None) are supported by the decoder, **but** the encoder only supports `Some`.
 * Keys in a key-value object must be strings, otherwise an error is returned.
+* Map and struct entries are sorted lexicographically by their key **before** they are encoded.
 * If you run into trouble encoding/decoding raw bytes, eg: `&[u8]` or `Vec<u8>` then use [this crate](https://crates.io/crates/serde_bytes).
 * The codebase is small (~1000 lines), easily digestible and filled with comments. If you're a first timer, you'll have a jolly time making your first contribution.

--- a/src/en.rs
+++ b/src/en.rs
@@ -28,6 +28,7 @@ use super::TYPE_END;
 /// * `Io` - An I/O error from the standard library.
 /// * `InvalidKeyType` - When you try encoding a map with keys that are not of type string.
 /// * `KeyWithNoValue` - When you try encoding a map entry's key without a value.
+/// * `ValueWithNoKey` - When you try encoding a map entry's value without a key.
 /// * `Unsupported` - When you try encoding a type that is not currently supported by the library.
 /// * `Serialize` - A custom serde serialization error.
 #[derive(Debug)]
@@ -38,6 +39,8 @@ pub enum Error {
     InvalidKeyType,
     /// Tried encoding a map entry's key without a value.
     KeyWithNoValue,
+    /// Tried encoding a map entry's value without a key.
+    ValueWithNoKey,
     /// Tried encoding a type that is not currently supported by the library.
     Unsupported(&'static str),
     /// A serde serialization error.
@@ -54,6 +57,9 @@ impl std::fmt::Display for Error {
             ),
             Error::KeyWithNoValue => {
                 write!(f, "tried encoding a map entry's key without a value")
+            }
+            Error::ValueWithNoKey => {
+                write!(f, "tried encoding a map entry's value without a key")
             }
             Error::Unsupported(ref ty) => {
                 write!(

--- a/src/en.rs
+++ b/src/en.rs
@@ -619,7 +619,8 @@ impl<'a, W: Write> Serializer for KeyEncoder<'a, W> {
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.en.serialize_str(v)
+        // The key encoder should just write the raw string to the buffer. Note that this means you would need to serialize it afterwards.
+        self.en.write(v.as_bytes())
     }
 
     fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {

--- a/src/en.rs
+++ b/src/en.rs
@@ -449,13 +449,14 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
 pub struct MapEncoder<'a, W> {
     encoder: &'a mut Encoder<W>,
     entries: BTreeMap<Vec<u8>, Vec<u8>>,
+    current_key: Option<Vec<u8>>,
 }
 
 impl<'a, W> MapEncoder<'a, W> {
     /// Constructs a new map encoder.
     #[inline]
     fn new(encoder: &'a mut Encoder<W>) -> MapEncoder<'a, W> {
-        Self { encoder, entries: BTreeMap::new() }
+        Self { encoder, entries: BTreeMap::new(), current_key: None }
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -948,4 +948,21 @@ mod test {
 
         assert_eq!(en.buf, b"d3:baz3:faz3:foo3:bare");
     }
+
+    #[test]
+    fn serialized_struct_is_sorted() {
+        #[derive(Debug, PartialEq, Serialize)]
+        struct Foo {
+            c: i32,
+            b: i32,
+            a: i32,
+        };
+
+        let foo = Foo { c: 3, b: 2, a: 1 };
+
+        let mut en = Encoder::new(vec![]);
+        foo.serialize(&mut en).unwrap();
+
+        assert_eq!(en.buf, b"d1:ai1e1:bi2e1:ci3ee")
+    }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -494,6 +494,7 @@ impl<'a, W: Write> SerializeMap for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
+        // We don't insert serialized keys into the BTreeMap, otherwise the keys will be sorted by their length first, eg: `1:z` will come before `2:aa`.
         let key = self.current_key.take().ok_or(Error::ValueWithNoKey)?;
         let val = super::encode(&value)?;
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -842,7 +842,7 @@ mod test {
         assert!(jerry.serialize(&mut en).is_ok());
         assert_eq!(
             en.buf,
-            b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe".to_vec()
+            b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe".to_vec()
         );
     }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -858,7 +858,7 @@ mod test {
 
         let mut en = Encoder::new(vec![]);
         assert!(jerry.serialize(&mut en).is_ok());
-        assert_eq!(en.buf, b"d4:name5:Jerry3:agei50ee".to_vec());
+        assert_eq!(en.buf, b"d3:agei50e4:name5:Jerrye".to_vec());
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -446,14 +446,14 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
 /// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
 #[derive(Debug)]
 pub struct MapEncoder<'a, W> {
-    en: &'a mut Encoder<W>,
+    encoder: &'a mut Encoder<W>,
 }
 
 impl<'a, W> MapEncoder<'a, W> {
     /// Constructs a new map encoder.
     #[inline]
-    fn new(en: &'a mut Encoder<W>) -> MapEncoder<'a, W> {
-        Self { en }
+    fn new(encoder: &'a mut Encoder<W>) -> MapEncoder<'a, W> {
+        Self { encoder }
     }
 }
 
@@ -466,7 +466,7 @@ impl<'a, W: Write> SerializeMap for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
-        key.serialize(KeyEncoder::new(self.en))
+        key.serialize(KeyEncoder::new(self.encoder))
     }
 
     fn serialize_value<T: ?Sized>(
@@ -476,11 +476,11 @@ impl<'a, W: Write> SerializeMap for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
-        value.serialize(&mut *self.en)
+        value.serialize(&mut *self.encoder)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.en.tag(TYPE_END)
+        self.encoder.tag(TYPE_END)
     }
 }
 
@@ -497,12 +497,12 @@ impl<'a, W: Write> SerializeStruct for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
-        key.serialize(&mut *self.en)?;
-        value.serialize(&mut *self.en)
+        key.serialize(&mut *self.encoder)?;
+        value.serialize(&mut *self.encoder)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.en.tag(TYPE_END)
+        self.encoder.tag(TYPE_END)
     }
 }
 
@@ -519,12 +519,12 @@ impl<'a, W: Write> SerializeStructVariant for MapEncoder<'a, W> {
     where
         T: serde::Serialize,
     {
-        key.serialize(&mut *self.en)?;
-        value.serialize(&mut *self.en)
+        key.serialize(&mut *self.encoder)?;
+        value.serialize(&mut *self.encoder)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.en.tag(TYPE_END)
+        self.encoder.tag(TYPE_END)
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -1,5 +1,6 @@
 //! Bencode encoding and serialization.
 
+use std::collections::BTreeMap;
 use std::io::Error as IoError;
 use std::io::Write;
 
@@ -447,13 +448,14 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
 #[derive(Debug)]
 pub struct MapEncoder<'a, W> {
     encoder: &'a mut Encoder<W>,
+    entries: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
 impl<'a, W> MapEncoder<'a, W> {
     /// Constructs a new map encoder.
     #[inline]
     fn new(encoder: &'a mut Encoder<W>) -> MapEncoder<'a, W> {
-        Self { encoder }
+        Self { encoder, entries: BTreeMap::new() }
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -26,6 +26,7 @@ use super::TYPE_END;
 ///
 /// * `Io` - An I/O error from the standard library.
 /// * `InvalidKeyType` - When you try encoding a map with keys that are not of type string.
+/// * `KeyWithNoValue` - When you try encoding a map entry's key without a value.
 /// * `Unsupported` - When you try encoding a type that is not currently supported by the library.
 /// * `Serialize` - A custom serde serialization error.
 #[derive(Debug)]
@@ -34,6 +35,8 @@ pub enum Error {
     Io(IoError),
     /// The encoder can only encode maps with keys that are of type string.
     InvalidKeyType,
+    /// Tried encoding a map entry's key without a value.
+    KeyWithNoValue,
     /// Tried encoding a type that is not currently supported by the library.
     Unsupported(&'static str),
     /// A serde serialization error.
@@ -48,6 +51,9 @@ impl std::fmt::Display for Error {
                 f,
                 "encoder can only encode keys that are of type string"
             ),
+            Error::KeyWithNoValue => {
+                write!(f, "tried encoding a map entry's key without a value")
+            }
             Error::Unsupported(ref ty) => {
                 write!(
                     f,

--- a/src/en.rs
+++ b/src/en.rs
@@ -448,7 +448,7 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
     }
 }
 
-/// An encoder used to encode key-values in a map or struct.
+/// An encoder used to store and **sort** map or struct entries **before** encoding them.
 ///
 /// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
 #[derive(Debug)]

--- a/src/en.rs
+++ b/src/en.rs
@@ -936,4 +936,16 @@ mod test {
         let mut en = Encoder::new(vec![]);
         assert!(map.serialize(&mut en).is_err());
     }
+
+    #[test]
+    fn serialized_map_is_sorted() {
+        let mut map = HashMap::new();
+        map.insert("foo", "bar");
+        map.insert("baz", "faz");
+
+        let mut en = Encoder::new(vec![]);
+        map.serialize(&mut en).unwrap();
+
+        assert_eq!(en.buf, b"d3:baz3:faz3:foo3:bare");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ const TYPE_END: u8 = 0x65;
 ///
 /// assert_eq!(
 ///     bende::encode(&jerry).unwrap(),
-///     b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe".to_vec()
+///     b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe".to_vec()
 /// );
 ///
 /// ```


### PR DESCRIPTION
As per #6, I've modified the `MapEncoder` type to sort key-value entries by key **before** encoding them.

First off, there are two new error types:

* `KeyWithNoValue` - When you try to encode a map entry's key without its respective value.
* `ValueWithNoKey` - When you try to encode a map entry's value without its respective key.

Then I modified the map encoder's fields, renaming the ambiguous `en` to `encoder` and adding two more fields:

 ```rust

pub struct MapEncoder<'a, W> {
    encoder: &'a mut Encoder<W>, // Renamed.
    entries: BTreeMap<Vec<u8>, Vec<u8>>, // Stores and sorts entries by their key upon insertion.
    current_key: Option<Vec<u8>>, // Keeps track of the current entry's key.
}

```

In addition to modifying the map encoder, I've also changed how `KeyEncoder` behaves:

### Before

```rust

fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
    self.en.serialize_str(v)
}

```

### After

```rust

fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
    self.en.write(v.as_bytes())
}

```

This is because we need to sort the key by their raw values **before** we encode them, otherwise the keys will be sorted by their **length** as well, which will result in this:

```
d
    3:zzz i0e
    4:aaaa 3:foo
e
```

The key `zzz` comes first as it is seen as `3:zzz` and `aaaa` will come second because it starts with `4`.

The other changes include:

* Changing the ordering of the encoded byte literals in tests and examples.
* I bumped the package version to `0.4.0`.
* I've updated the README to reflect that you need serde as a dependency to use any of the encoding/decode methods. And I also added a note to let users know that when they encode maps and structs, their entries will be sorted first.

This is quite a change, but I doubt more changes of this magnitude will be added in the future.