### PR TITLE
Feature: A Value type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.4.1"
+version = "0.5.0"
 
 authors = ["Rick <rickz75dev@gmail.com>", "Halfnelson <ewoudvanrooyen@gmail.com>"]
 description = "A bencode encoding/decoding implementation backed by serde."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the library as a dependency to [Cargo.toml](https://doc.rust-lang.org/cargo/
 
 ```toml
 [dependencies]
-bende = "0.4.0"
+bende = "0.5.0"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod de;
 pub mod en;
+pub mod value;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! * [`decode`] - Which you can use to decode bencoded bytes into a **deserializable** type.
 //! * [`encode`] - Which you can use to encode a **serializable** type into bencoded bytes.
 //!
+//! Additionally, we have the [`Value`] type that represents any valid bencode data type. It also implements [`Serialize`] and [`Deserialize`].
+//!
 //! You'd also find error types for both encoding and decoding, alongside the [`Encoder`](en::Encoder) and [`Decoder`](de::Decoder) types.
 
 pub mod de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ pub mod de;
 pub mod en;
 pub mod value;
 
+pub use value::Value;
+
 use serde::{Deserialize, Serialize};
 
 /// Denotes the start of an integer - `i`.

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,5 +1,10 @@
+use std::collections::BTreeMap;
+
 /// A list of bencode values.
 pub type List = Vec<Value>;
+
+/// A **sorted** key-value map with keys that are UTF-8 valid strings.
+pub type Dict = BTreeMap<String, Value>;
 
 /// Represents any valid data type that can be encoded/decoded to and from bencode.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -185,4 +185,12 @@ mod test {
             Value::Text(b"foo".to_vec())
         );
     }
+
+    #[test]
+    fn decode_value_list() {
+        assert_eq!(
+            decode::<Value>(b"li1995e3:fooe").unwrap(),
+            Value::List(vec![Value::Int(1995), Value::Text(b"foo".to_vec())])
+        )
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,4 +3,6 @@
 pub enum Value {
     /// A 64-bit signed integer.
     Int(i64),
+    /// An array of bytes that may or **may not** be valid UTF-8.
+    Text(Vec<u8>),
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -191,6 +191,12 @@ impl From<&[Value]> for Value {
     }
 }
 
+impl From<Vec<Value>> for Value {
+    fn from(v: Vec<Value>) -> Self {
+        Value::List(v)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -173,6 +173,12 @@ impl From<Vec<u8>> for Value {
     }
 }
 
+impl From<&str> for Value {
+    fn from(v: &str) -> Self {
+        Value::Text(v.as_bytes().to_owned())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,3 @@
+/// Represents any valid data type that can be encoded/decoded to and from bencode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Value {}

--- a/src/value.rs
+++ b/src/value.rs
@@ -151,6 +151,9 @@ macro_rules! impl_value_from_num {
     }
 }
 
+// We need to skip i64.
+impl_value_from_num!(u8, u16, u32, u64, usize, i8, i16, i32, isize);
+
 // We do this manually as to avoid casting `i64 as i64`.
 impl From<i64> for Value {
     fn from(v: i64) -> Self {

--- a/src/value.rs
+++ b/src/value.rs
@@ -51,6 +51,8 @@ impl Serialize for Value {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::Value;
     use crate::{decode, encode};
 
@@ -71,5 +73,14 @@ mod test {
         let mut val =
             Value::List(vec![Value::Int(1995), Value::Text(b"foo".to_vec())]);
         assert_eq!(encode(&val).unwrap(), b"li1995e3:fooe");
+    }
+
+    #[test]
+    fn encode_value_dict() {
+        let mut map = HashMap::new();
+        map.insert("foo".to_string(), Value::Int(1995));
+        map.insert("bar".to_string(), Value::Text(b"faz".to_vec()));
+
+        assert_eq!(encode(&map).unwrap(), b"d3:bar3:faz3:fooi1995ee");
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,4 +8,6 @@ pub enum Value {
     Int(i64),
     /// An array of bytes that may or **may not** be valid UTF-8.
     Text(Vec<u8>),
+    /// A list of bencode values.
+    List(List),
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -161,6 +161,12 @@ impl From<i64> for Value {
     }
 }
 
+impl From<&[u8]> for Value {
+    fn from(v: &[u8]) -> Self {
+        Value::Text(v.to_owned())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -172,4 +172,9 @@ mod test {
 
         assert_eq!(encode(&map).unwrap(), b"d3:bar3:faz3:fooi1995ee");
     }
+
+    #[test]
+    fn decode_value_int() {
+        assert_eq!(decode::<Value>(b"i1995e").unwrap(), Value::Int(1995));
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -179,6 +179,12 @@ impl From<&str> for Value {
     }
 }
 
+impl From<String> for Value {
+    fn from(v: String) -> Self {
+        Value::Text(v.into_bytes())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -177,4 +177,12 @@ mod test {
     fn decode_value_int() {
         assert_eq!(decode::<Value>(b"i1995e").unwrap(), Value::Int(1995));
     }
+
+    #[test]
+    fn decode_value_text() {
+        assert_eq!(
+            decode::<Value>(b"3:foo").unwrap(),
+            Value::Text(b"foo".to_vec())
+        );
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -59,4 +59,10 @@ mod test {
         let mut val = Value::Int(1995);
         assert_eq!(encode(&val).unwrap(), b"i1995e");
     }
+
+    #[test]
+    fn encode_value_text() {
+        let mut val = Value::Text(b"foo".to_vec());
+        assert_eq!(encode(&val).unwrap(), b"3:foo");
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -167,6 +167,12 @@ impl From<&[u8]> for Value {
     }
 }
 
+impl From<Vec<u8>> for Value {
+    fn from(v: Vec<u8>) -> Self {
+        Value::Text(v)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -65,4 +65,11 @@ mod test {
         let mut val = Value::Text(b"foo".to_vec());
         assert_eq!(encode(&val).unwrap(), b"3:foo");
     }
+
+    #[test]
+    fn encode_value_list() {
+        let mut val =
+            Value::List(vec![Value::Int(1995), Value::Text(b"foo".to_vec())]);
+        assert_eq!(encode(&val).unwrap(), b"li1995e3:fooe");
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt;
 
 use serde::de::Visitor;
@@ -194,6 +195,12 @@ impl From<&[Value]> for Value {
 impl From<Vec<Value>> for Value {
     fn from(v: Vec<Value>) -> Self {
         Value::List(v)
+    }
+}
+
+impl From<HashMap<String, Value>> for Value {
+    fn from(v: HashMap<String, Value>) -> Self {
+        Value::Dict(BTreeMap::from_iter(v.into_iter()))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -138,6 +138,19 @@ impl<'de> Deserialize<'de> for Value {
     }
 }
 
+/// Implements `From<T> for Value` for any numerical type.
+macro_rules! impl_value_from_num {
+    ($($t:ty),*) => {
+        $(
+            impl From<$t> for Value {
+                fn from(v: $t) -> Value {
+                    Value::Int(v as i64)
+                }
+            }
+        )*
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -151,6 +151,13 @@ macro_rules! impl_value_from_num {
     }
 }
 
+// We do this manually as to avoid casting `i64 as i64`.
+impl From<i64> for Value {
+    fn from(v: i64) -> Self {
+        Value::Int(v)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -185,6 +185,12 @@ impl From<String> for Value {
     }
 }
 
+impl From<&[Value]> for Value {
+    fn from(v: &[Value]) -> Self {
+        Value::List(v.iter().cloned().collect())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -48,3 +48,15 @@ impl Serialize for Value {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Value;
+    use crate::{decode, encode};
+
+    #[test]
+    fn encode_value_int() {
+        let mut val = Value::Int(1995);
+        assert_eq!(encode(&val).unwrap(), b"i1995e");
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,4 +15,6 @@ pub enum Value {
     Text(Vec<u8>),
     /// A list of bencode values.
     List(List),
+    /// A key-value map with keys that are UTF-8 valid strings.
+    Dict(Dict),
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -204,6 +204,12 @@ impl From<HashMap<String, Value>> for Value {
     }
 }
 
+impl From<BTreeMap<String, Value>> for Value {
+    fn from(v: BTreeMap<String, Value>) -> Self {
+        Value::Dict(v)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/src/value.rs
+++ b/src/value.rs
@@ -140,7 +140,7 @@ impl<'de> Deserialize<'de> for Value {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use super::Value;
     use crate::{decode, encode};
@@ -191,6 +191,17 @@ mod test {
         assert_eq!(
             decode::<Value>(b"li1995e3:fooe").unwrap(),
             Value::List(vec![Value::Int(1995), Value::Text(b"foo".to_vec())])
+        )
+    }
+
+    #[test]
+    fn decode_value_dict() {
+        let mut map = BTreeMap::new();
+        map.insert("foo".to_string(), Value::Int(1995));
+        map.insert("bar".to_string(), Value::Text(b"faz".to_vec()));
+        assert_eq!(
+            decode::<Value>(b"d3:bar3:faz3:fooi1995ee").unwrap(),
+            Value::Dict(map)
         )
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,6 @@
+/// A list of bencode values.
+pub type List = Vec<Value>;
+
 /// Represents any valid data type that can be encoded/decoded to and from bencode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,11 @@
+//! Bencode data types.
+//!
+//! The types included in this module are:
+//!
+//! * [`Value`] - An enumeration over the different bencode data types.
+//! * [`List`] - A list of bencode values.
+//! * [`Dict`] - A **sorted** key-value object.
+
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt;

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,6 @@
 /// Represents any valid data type that can be encoded/decoded to and from bencode.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Value {}
+pub enum Value {
+    /// A 64-bit signed integer.
+    Int(i64),
+}


### PR DESCRIPTION
This PR introduces a new `Value` type - an enum that can represent any valid bencode data type.

The `en.rs` and `de.rs` modules have been left untouched. The only change to `lib.rs` is that it exports the value type, and that it's docs now mention the new value type.

This is a **major change** so I also bumped the package version to `0.5.0`.