### PR TITLE
Internal/test rework

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -667,8 +667,15 @@ mod test {
 
     #[test]
     fn decode_int_unsigned() {
-        let mut de = Decoder::new(b"i1995e");
-        assert_eq!(de.decode_int(), Ok(1995));
+        test_decode!(u8, b"i255e", Ok(255));
+        test_decode!(u16, b"i255e", Ok(255));
+        test_decode!(u32, b"i255e", Ok(255));
+        test_decode!(usize, b"i255e", Ok(255));
+
+        test_decode!(i8, b"i127e", Ok(127));
+        test_decode!(i16, b"i127e", Ok(127));
+        test_decode!(i32, b"i127e", Ok(127));
+        test_decode!(isize, b"i127e", Ok(127));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -752,8 +752,7 @@ mod test {
 
     #[test]
     fn decode_bytes_empty() {
-        let mut de = Decoder::new(b"0:");
-        assert_eq!(de.decode_bytes(), Ok(b"".as_slice()));
+        test_decode!(b"0:", Ok(Bytes::new(b"")));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -720,6 +720,12 @@ mod test {
     }
 
     #[test]
+    fn decode_float_err() {
+        test_decode!(f32, b"i1995e", Err(Error::Unsupported("f32")));
+        test_decode!(f64, b"i1995e", Err(Error::Unsupported("f64")));
+    }
+
+    #[test]
     fn decode_len_ok() {
         let mut de = Decoder::new(b"13:x");
         assert_eq!(de.decode_len(), Ok(13));

--- a/src/de.rs
+++ b/src/de.rs
@@ -693,15 +693,15 @@ mod test {
 
     #[test]
     fn decode_int_wrong_tag() {
-        let mut de = Decoder::new(b"e1995e");
-        assert_eq!(
-            de.decode_int(),
+        test_decode!(
+            i32,
+            b"e1995e",
             Err(Error::Wanted {
                 at: 0,
                 expected: "an integer",
                 found: "e".to_string()
             })
-        )
+        );
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -688,8 +688,7 @@ mod test {
 
     #[test]
     fn decode_int_zero() {
-        let mut de = Decoder::new(b"i0e");
-        assert_eq!(de.decode_int(), Ok(0));
+        test_decode!(b"i0e", Ok(0));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -649,9 +649,11 @@ mod test {
     use std::collections::HashMap;
 
     use serde::Deserialize;
+    use serde_bytes::ByteBuf;
     use serde_bytes::Bytes;
 
-    use super::{Decoder, Error};
+    use super::Decoder;
+    use super::Error;
 
     /// Asserts that the result of decoding the encoded bytes is equal to the given value.
     macro_rules! test_decode {
@@ -751,14 +753,13 @@ mod test {
     }
 
     #[test]
-    fn decode_bytes_empty() {
-        test_decode!(b"0:", Ok(Bytes::new(b"")));
+    fn decode_bytes_err() {
+        test_decode!(ByteBuf, b"4:foo", Err(Error::EOF));
     }
 
     #[test]
-    fn decode_bytes_err() {
-        let mut de = Decoder::new(b"4:foo");
-        assert_eq!(de.decode_bytes(), Err(Error::EOF))
+    fn decode_bytes_empty() {
+        test_decode!(b"0:", Ok(Bytes::new(b"")));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -795,6 +795,16 @@ mod test {
     }
 
     #[test]
+    fn deserialize_none() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        }
+        test_decode!(b"d3:agei50ee", Ok(Person { name: None, age: 50 }));
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {
@@ -815,21 +825,6 @@ mod test {
                 }
             )
         );
-    }
-
-    #[test]
-    fn deserialize_none() {
-        #[derive(Debug, PartialEq, Deserialize)]
-        struct Person {
-            name: Option<String>,
-            age: u8,
-        }
-
-        let mut de = Decoder::new(b"d3:agei50ee");
-        assert_eq!(
-            Person::deserialize(&mut de),
-            Ok(Person { name: None, age: 50 })
-        )
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -830,9 +830,7 @@ mod test {
     fn deserialize_newtype_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Foo(i32);
-
-        let mut de = Decoder::new(b"i1995e");
-        assert_eq!(Foo::deserialize(&mut de), Ok(Foo(1995)));
+        test_decode!(b"i1995e", Ok(Foo(1995)));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -652,6 +652,19 @@ mod test {
 
     use super::{Decoder, Error};
 
+    /// Asserts that the result of decoding the encoded bytes is equal to the given value.
+    macro_rules! test_decode {
+        ($enc:expr, $res:expr) => {
+            let mut de = Decoder::new($enc);
+            assert_eq!(Deserialize::deserialize(&mut de), $res);
+        };
+
+        ($t:ident, $enc:expr, $res:expr) => {
+            let mut de = Decoder::new($enc);
+            assert_eq!($t::deserialize(&mut de), $res);
+        };
+    }
+
     #[test]
     fn decode_int_unsigned() {
         let mut de = Decoder::new(b"i1995e");

--- a/src/de.rs
+++ b/src/de.rs
@@ -764,11 +764,8 @@ mod test {
 
     #[test]
     fn decode_bool_ok() {
-        let mut de = Decoder::new(b"i0e");
-        assert_eq!(de.decode_bool(), Ok(false));
-
-        let mut de = Decoder::new(b"i1e");
-        assert_eq!(de.decode_bool(), Ok(true));
+        test_decode!(b"i0e", Ok(false));
+        test_decode!(b"i1e", Ok(true));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -770,15 +770,15 @@ mod test {
 
     #[test]
     fn decode_bool_err() {
-        let mut de = Decoder::new(b"i2e");
-        assert_eq!(
-            de.decode_bool(),
+        test_decode!(
+            bool,
+            b"i2e",
             Err(Error::Wanted {
                 at: 0,
                 expected: "a boolean",
                 found: "2".to_string()
             })
-        )
+        );
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -649,6 +649,7 @@ mod test {
     use std::collections::HashMap;
 
     use serde::Deserialize;
+    use serde_bytes::Bytes;
 
     use super::{Decoder, Error};
 
@@ -746,9 +747,7 @@ mod test {
 
     #[test]
     fn decode_bytes_ok() {
-        let mut de = Decoder::new(b"3:foox");
-        assert_eq!(de.decode_bytes(), Ok(b"foo".as_slice()));
-        assert_eq!(de.next(), Some(b'x'));
+        test_decode!(b"3:foo", Ok(Bytes::new(b"foo")));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -808,9 +808,7 @@ mod test {
     fn deserialize_unit_struct_ok() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Unit;
-
-        let mut de = Decoder::new(b"4:Unit");
-        assert_eq!(Unit::deserialize(&mut de), Ok(Unit));
+        test_decode!(b"4:Unit", Ok(Unit));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -782,7 +782,7 @@ mod test {
     }
 
     #[test]
-    fn deserialize_simple() {
+    fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {
             name: String,
@@ -791,18 +791,17 @@ mod test {
             #[serde(with = "serde_bytes")]
             signature: Vec<u8>,
         }
-
-        let jerry = Person {
-            name: "Jerry Smith".to_string(),
-            age: 50,
-            is_employed: false,
-            signature: b"jsmith".to_vec(),
-        };
-
-        let mut de =
-            Decoder::new(b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe");
-
-        assert_eq!(Person::deserialize(&mut de), Ok(jerry));
+        test_decode!(
+            b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe",
+            Ok(
+                Person {
+                    name: "Jerry Smith".to_string(),
+                    age: 50,
+                    is_employed: false,
+                    signature: b"jsmith".to_vec(),
+                }
+            )
+        );
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -706,8 +706,7 @@ mod test {
 
     #[test]
     fn decode_int_invalid_digits() {
-        let mut de = Decoder::new(b"i199xe");
-        assert_eq!(de.decode_int(), Err(Error::Malformed))
+        test_decode!(i32, b"i199xe", Err(Error::Malformed));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -782,6 +782,19 @@ mod test {
     }
 
     #[test]
+    fn deserialize_some() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Person {
+            name: Option<String>,
+            age: u8,
+        }
+        test_decode!(
+            b"d4:name5:Jerry3:agei50ee",
+            Ok(Person { name: Some("Jerry".to_string()), age: 50 })
+        );
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {
@@ -802,21 +815,6 @@ mod test {
                 }
             )
         );
-    }
-
-    #[test]
-    fn deserialize_some() {
-        #[derive(Debug, PartialEq, Deserialize)]
-        struct Person {
-            name: Option<String>,
-            age: u8,
-        }
-
-        let mut de = Decoder::new(b"d4:name5:Jerry3:agei50ee");
-        assert_eq!(
-            Person::deserialize(&mut de),
-            Ok(Person { name: Some("Jerry".to_string()), age: 50 })
-        )
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -838,8 +838,7 @@ mod test {
         let mut map = HashMap::new();
         map.insert("foo", "bar");
 
-        let mut de = Decoder::new(b"d3:foo3:bare");
-        assert_eq!(HashMap::deserialize(&mut de), Ok(map))
+        test_decode!(b"d3:foo3:bare", Ok(map));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -815,10 +815,9 @@ mod test {
     fn deserialize_unit_struct_err() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Unit;
-
-        let mut de = Decoder::new(b"3:Foo");
-        assert_eq!(
-            Unit::deserialize(&mut de),
+        test_decode!(
+            Unit,
+            b"3:Foo",
             Err(Error::Wanted {
                 at: 0,
                 expected: "Unit",

--- a/src/de.rs
+++ b/src/de.rs
@@ -680,8 +680,10 @@ mod test {
 
     #[test]
     fn decode_int_signed() {
-        let mut de = Decoder::new(b"i-1995e");
-        assert_eq!(de.decode_int(), Ok(-1995));
+        test_decode!(i8, b"i-127e", Ok(-127));
+        test_decode!(i16, b"i-127e", Ok(-127));
+        test_decode!(i32, b"i-127e", Ok(-127));
+        test_decode!(isize, b"i-127e", Ok(-127));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -843,11 +843,10 @@ mod test {
 
     #[test]
     fn deserialize_map_err() {
-        let mut de = Decoder::new(b"di1995e3:fooe");
-        assert_eq!(
-            HashMap::<i32, &str>::deserialize(&mut de),
-            Err(Error::Malformed)
-        )
+        // Rework to supply the macro with an explicit type.
+        type BadMap = HashMap<i32, String>;
+
+        test_decode!(BadMap, b"di1995e3:fooe", Err(Error::Malformed));
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -805,29 +805,6 @@ mod test {
     }
 
     #[test]
-    fn deserialize_simple_struct() {
-        #[derive(Debug, PartialEq, Deserialize)]
-        struct Person {
-            name: String,
-            age: u8,
-            is_employed: bool,
-            #[serde(with = "serde_bytes")]
-            signature: Vec<u8>,
-        }
-        test_decode!(
-            b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe",
-            Ok(
-                Person {
-                    name: "Jerry Smith".to_string(),
-                    age: 50,
-                    is_employed: false,
-                    signature: b"jsmith".to_vec(),
-                }
-            )
-        );
-    }
-
-    #[test]
     fn deserialize_unit_struct_ok() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Unit;
@@ -877,5 +854,28 @@ mod test {
             HashMap::<i32, &str>::deserialize(&mut de),
             Err(Error::Malformed)
         )
+    }
+
+    #[test]
+    fn deserialize_simple_struct() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Person {
+            name: String,
+            age: u8,
+            is_employed: bool,
+            #[serde(with = "serde_bytes")]
+            signature: Vec<u8>,
+        }
+        test_decode!(
+            b"d4:name11:Jerry Smith3:agei50e11:is_employedi0e9:signature6:jsmithe",
+            Ok(
+                Person {
+                    name: "Jerry Smith".to_string(),
+                    age: 50,
+                    is_employed: false,
+                    signature: b"jsmith".to_vec(),
+                }
+            )
+        );
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -849,12 +849,10 @@ mod test {
             name: Option<String>,
             age: u8,
         }
-
-        let jerry = Person { name: Some("Jerry".to_owned()), age: 50 };
-
-        let mut en = Encoder::new(vec![]);
-        assert!(jerry.serialize(&mut en).is_ok());
-        assert_eq!(en.buf, b"d3:agei50e4:name5:Jerrye".to_vec());
+        test_encode!(
+            Person { name: Some("Jerry".to_owned()), age: 50 },
+            b"d3:agei50e4:name5:Jerrye"
+        );
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -876,10 +876,7 @@ mod test {
     fn serialize_unit_struct() {
         #[derive(Debug, Serialize)]
         struct Unit;
-
-        let mut en = Encoder::new(vec![]);
-        Unit.serialize(&mut en).unwrap();
-        assert_eq!(en.buf, b"4:Unit".to_vec());
+        test_encode!(Unit, b"4:Unit");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -809,9 +809,10 @@ mod test {
 
     #[test]
     fn encode_int_signed() {
-        let mut en = Encoder::new(vec![]);
-        assert!(en.encode_int(-1995).is_ok());
-        assert_eq!(en.buf, b"i-1995e".to_vec());
+        test_encode!(-127i8, b"i-127e");
+        test_encode!(-127i16, b"i-127e");
+        test_encode!(-127i32, b"i-127e");
+        test_encode!(-127i64, b"i-127e");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -834,9 +834,7 @@ mod test {
 
     #[test]
     fn encode_bytes_empty() {
-        let mut en = Encoder::new(vec![]);
-        assert!(en.encode_bytes(b"").is_ok());
-        assert_eq!(en.buf, b"0:".to_vec());
+        test_encode!(Bytes::new(b""), b"0:");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -963,12 +963,6 @@ mod test {
             b: i32,
             a: i32,
         }
-
-        let foo = Foo { c: 3, b: 2, a: 1 };
-
-        let mut en = Encoder::new(vec![]);
-        foo.serialize(&mut en).unwrap();
-
-        assert_eq!(en.buf, b"d1:ai1e1:bi2e1:ci3ee")
+        test_encode!(Foo { c: 3, b: 2, a: 1 }, b"d1:ai1e1:bi2e1:ci3ee");
     }
 }

--- a/src/en.rs
+++ b/src/en.rs
@@ -796,9 +796,15 @@ mod test {
 
     #[test]
     fn encode_int_unsigned() {
-        let mut en = Encoder::new(vec![]);
-        assert!(en.encode_int(1995).is_ok());
-        assert_eq!(en.buf, b"i1995e".to_vec());
+        test_encode!(255u8, b"i255e");
+        test_encode!(255u16, b"i255e");
+        test_encode!(255u32, b"i255e");
+        test_encode!(255u64, b"i255e");
+
+        test_encode!(127i8, b"i127e");
+        test_encode!(127i16, b"i127e");
+        test_encode!(127i32, b"i127e");
+        test_encode!(127i64, b"i127e");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -931,10 +931,7 @@ mod test {
         map.insert("foo", "bar");
         map.insert("baz", "faz");
 
-        let mut en = Encoder::new(vec![]);
-        map.serialize(&mut en).unwrap();
-
-        assert_eq!(en.buf, b"d3:baz3:faz3:foo3:bare");
+        test_encode!(map, b"d3:baz3:faz3:foo3:bare");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -785,6 +785,15 @@ mod test {
     use super::Encoder;
     use super::KeyEncoder;
 
+    /// Asserts that the result of encoding the value is equal to the given bencoded bytes.
+    macro_rules! test_encode {
+        ($val:expr, $res:expr) => {
+            let mut en = Encoder::new(vec![]);
+            $val.serialize(&mut en).unwrap();
+            assert_eq!(en.buf, $res);
+        };
+    }
+
     #[test]
     fn encode_int_unsigned() {
         let mut en = Encoder::new(vec![]);

--- a/src/en.rs
+++ b/src/en.rs
@@ -863,11 +863,7 @@ mod test {
             name: Option<String>,
             age: u8,
         }
-
-        let jerry = Person { name: None, age: 50 };
-
-        let mut en = Encoder::new(vec![]);
-        jerry.serialize(&mut en).unwrap();
+        test_encode!(Person { name: None, age: 50 }, b"");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -843,6 +843,12 @@ mod test {
     }
 
     #[test]
+    fn encode_bool() {
+        test_encode!(false, b"i0e");
+        test_encode!(true, b"i1e");
+    }
+
+    #[test]
     fn serialize_some() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -883,10 +883,7 @@ mod test {
     fn serialize_newtype_struct() {
         #[derive(Debug, Serialize)]
         struct Foo(i32);
-
-        let mut en = Encoder::new(vec![]);
-        Foo(1995).serialize(&mut en).unwrap();
-        assert_eq!(en.buf, b"i1995e".to_vec());
+        test_encode!(Foo(1995), b"i1995e");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -913,8 +913,7 @@ mod test {
         let mut map = HashMap::new();
         map.insert("foo", "bar");
 
-        let mut en = Encoder::new(vec![]);
-        assert!(map.serialize(&mut en).is_ok());
+        test_encode!(map, b"d3:foo3:bare");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -944,19 +944,14 @@ mod test {
             #[serde(with = "serde_bytes")]
             signature: Vec<u8>,
         }
-
-        let jerry = Person {
-            name: "Jerry Smith".to_string(),
-            age: 50,
-            is_employed: false,
-            signature: b"jsmith".to_vec(),
-        };
-
-        let mut en = Encoder::new(vec![]);
-        assert!(jerry.serialize(&mut en).is_ok());
-        assert_eq!(
-            en.buf,
-            b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe".to_vec()
+        test_encode!(
+            Person {
+                name: "Jerry Smith".to_string(),
+                age: 50,
+                is_employed: false,
+                signature: b"jsmith".to_vec(),
+            },
+            b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe"
         );
     }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -917,12 +917,12 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
     fn serialize_map_err() {
         let mut map = HashMap::new();
         map.insert(0, "bar");
 
-        let mut en = Encoder::new(vec![]);
-        assert!(map.serialize(&mut en).is_err());
+        test_encode!(map, b"");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -817,9 +817,7 @@ mod test {
 
     #[test]
     fn encode_int_zero() {
-        let mut en = Encoder::new(vec![]);
-        assert!(en.encode_int(0).is_ok());
-        assert_eq!(en.buf, b"i0e".to_vec());
+        test_encode!(0, b"i0e");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -781,6 +781,7 @@ mod test {
     use std::collections::HashMap;
 
     use serde::Serialize;
+    use serde_bytes::Bytes;
 
     use super::Encoder;
     use super::KeyEncoder;
@@ -828,9 +829,7 @@ mod test {
 
     #[test]
     fn encode_bytes() {
-        let mut en = Encoder::new(vec![]);
-        assert!(en.encode_bytes(b"hello").is_ok());
-        assert_eq!(en.buf, b"5:hello".to_vec());
+        test_encode!(Bytes::new(b"hello"), b"5:hello");
     }
 
     #[test]

--- a/src/en.rs
+++ b/src/en.rs
@@ -838,6 +838,11 @@ mod test {
     }
 
     #[test]
+    fn encode_str() {
+        test_encode!("hello", b"5:hello");
+    }
+
+    #[test]
     fn serialize_simple() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -821,6 +821,12 @@ mod test {
     }
 
     #[test]
+    #[should_panic]
+    fn encode_float_err() {
+        test_encode!(0.0, b"");
+    }
+
+    #[test]
     fn encode_bytes() {
         let mut en = Encoder::new(vec![]);
         assert!(en.encode_bytes(b"hello").is_ok());

--- a/src/en.rs
+++ b/src/en.rs
@@ -843,32 +843,6 @@ mod test {
     }
 
     #[test]
-    fn serialize_simple() {
-        #[derive(Debug, PartialEq, Serialize)]
-        struct Person {
-            name: String,
-            age: u8,
-            is_employed: bool,
-            #[serde(with = "serde_bytes")]
-            signature: Vec<u8>,
-        }
-
-        let jerry = Person {
-            name: "Jerry Smith".to_string(),
-            age: 50,
-            is_employed: false,
-            signature: b"jsmith".to_vec(),
-        };
-
-        let mut en = Encoder::new(vec![]);
-        assert!(jerry.serialize(&mut en).is_ok());
-        assert_eq!(
-            en.buf,
-            b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe".to_vec()
-        );
-    }
-
-    #[test]
     fn serialize_some() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {
@@ -968,6 +942,32 @@ mod test {
         map.serialize(&mut en).unwrap();
 
         assert_eq!(en.buf, b"d3:baz3:faz3:foo3:bare");
+    }
+
+    #[test]
+    fn serialize_simple_struct() {
+        #[derive(Debug, PartialEq, Serialize)]
+        struct Person {
+            name: String,
+            age: u8,
+            is_employed: bool,
+            #[serde(with = "serde_bytes")]
+            signature: Vec<u8>,
+        }
+
+        let jerry = Person {
+            name: "Jerry Smith".to_string(),
+            age: 50,
+            is_employed: false,
+            signature: b"jsmith".to_vec(),
+        };
+
+        let mut en = Encoder::new(vec![]);
+        assert!(jerry.serialize(&mut en).is_ok());
+        assert_eq!(
+            en.buf,
+            b"d3:agei50e11:is_employedi0e4:name11:Jerry Smith9:signature6:jsmithe".to_vec()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,10 +204,6 @@ mod test {
     fn encode_and_decode_newtype_struct() {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         struct Foo(i32);
-
-        let foo = Foo(1995);
-
-        let bytes = encode(&foo).unwrap();
-        assert_eq!(decode::<Foo>(&bytes), Ok(foo));
+        test_bende!(Foo, Foo(1995));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ mod test {
     }
 
     #[test]
-    fn encode_and_decode_nested() {
+    fn encode_and_decode_nested_struct() {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         struct Armory {
             weapons: Vec<Weapon>,
@@ -158,21 +158,21 @@ mod test {
             damage: u8,
         }
 
-        let armory = Armory {
-            weapons: vec![
-                Weapon {
-                    name: "Sword".to_string(),
-                    stats: Stats { health: 64, damage: 27 },
-                },
-                Weapon {
-                    name: "Shield".to_string(),
-                    stats: Stats { health: 102, damage: 0 },
-                },
-            ],
-        };
-
-        let bytes = encode(&armory).unwrap();
-        assert_eq!(decode::<Armory>(&bytes).unwrap(), armory);
+        test_bende!(
+            Armory,
+            Armory {
+                weapons: vec![
+                    Weapon {
+                        name: "Sword".to_string(),
+                        stats: Stats { health: 64, damage: 27 },
+                    },
+                    Weapon {
+                        name: "Shield".to_string(),
+                        stats: Stats { health: 102, damage: 0 },
+                    },
+                ],
+            }
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,15 +183,14 @@ mod test {
             age: Option<u8>,
             is_employed: Option<bool>,
         }
-
-        let jerry = Person {
-            name: Some("Jerry Smith".to_string()),
-            age: Some(50),
-            is_employed: Some(false),
-        };
-
-        let bytes = encode(&jerry).unwrap();
-        assert_eq!(decode::<Person>(&bytes).unwrap(), jerry);
+        test_bende!(
+            Person,
+            Person {
+                name: Some("Jerry Smith".to_string()),
+                age: Some(50),
+                is_employed: Some(false),
+            }
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,15 +129,14 @@ mod test {
             age: u8,
             is_employed: bool,
         }
-
-        let jerry = Person {
-            name: "Jerry Smith".to_string(),
-            age: 50,
-            is_employed: false,
-        };
-
-        let bytes = encode(&jerry).unwrap();
-        assert_eq!(decode::<Person>(&bytes).unwrap(), jerry);
+        test_bende!(
+            Person,
+            Person {
+                name: "Jerry Smith".to_string(),
+                age: 50,
+                is_employed: false,
+            }
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,9 +197,7 @@ mod test {
     fn encode_and_decode_unit_struct() {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         struct Foo;
-
-        let bytes = encode(&Foo).unwrap();
-        assert_eq!(decode::<Foo>(&bytes).unwrap(), Foo);
+        test_bende!(Foo, Foo);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,14 @@ mod test {
     use super::decode;
     use super::encode;
 
+    /// Asserts that passing the encoded value's bytes to the decoder will yield the same value.
+    macro_rules! test_bende {
+        ($t:ident, $val:expr) => {
+            let bytes = encode(&$val).unwrap();
+            assert_eq!(decode::<$t>(&bytes), Ok($val));
+        };
+    }
+
     #[test]
     fn encode_and_decode_simple() {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR cleans up the unit tests for the following modules:

- `de.rs`
- `en.rs`
- `lib.rs`

I've added the macros `test_decode`, `test_encode`, and `test_bende` to each of these modules respectively, and used them to refactor repetitive testing patterns into a clearer and more readable code.

Should this be merged into the main branch, then I believe it should resolve #3.

Since there is no change in the public or private API, the version will remain the same as it is now.