### PR TITLE
Feature: Enum Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bende"
-version = "0.5.3"
+version = "0.5.4"
 
 authors = [
     "Rick <rickz75dev@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the library as a dependency to [Cargo.toml](https://doc.rust-lang.org/cargo/
 
 ```toml
 [dependencies]
-bende = "0.5.3"
+bende = "0.5.4"
 serde = { version = "1", features = ["derive"] }
 ```
 
@@ -50,13 +50,10 @@ assert_eq!(bende::decode::<Person>(&bytes).unwrap(), jerry);
 
 ## Unsupported Types
 
-The types that are currently **not supported** are:
+The types that are **not supported** are:
 
 * `f32`
 * `f64`
-* `enum`
-
-Floats will never be supported, but `enum` support will probably be added in the future.
 
 ## Contributing
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -966,6 +966,19 @@ mod test {
     }
 
     #[test]
+    fn deserialize_newtype_variant() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        enum Enum {
+            Foo(i32),
+            Bar(String),
+            Baz(bool),
+        }
+        test_decode!(b"d3:Fooi50ee", Ok(Enum::Foo(50)));
+        test_decode!(b"d3:Bar5:helloe", Ok(Enum::Bar("hello".to_string())));
+        test_decode!(b"d3:Bazi1ee", Ok(Enum::Baz(true)));
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {

--- a/src/de.rs
+++ b/src/de.rs
@@ -953,6 +953,19 @@ mod test {
     }
 
     #[test]
+    fn deserialize_unit_variant() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        enum Enum {
+            Foo,
+            Bar,
+            Baz,
+        }
+        test_decode!(b"3:Foo", Ok(Enum::Foo));
+        test_decode!(b"3:Bar", Ok(Enum::Bar));
+        test_decode!(b"3:Baz", Ok(Enum::Baz));
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {

--- a/src/de.rs
+++ b/src/de.rs
@@ -6,6 +6,7 @@ use std::string::FromUtf8Error;
 
 use serde::de::MapAccess;
 use serde::de::SeqAccess;
+use serde::de::VariantAccess;
 use serde::Deserializer;
 
 use super::DICT_START;
@@ -574,6 +575,43 @@ impl<'a, 'de> Deserializer<'de> for &'a mut Decoder<'de> {
         V: serde::de::Visitor<'de>,
     {
         self.deserialize_any(visitor)
+    }
+}
+
+impl<'a, 'de> VariantAccess<'de> for &'a mut Decoder<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self)
+    }
+
+    fn tuple_variant<V>(
+        self,
+        _: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        _: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -4,6 +4,7 @@ use std::str;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
+use serde::de::EnumAccess;
 use serde::de::MapAccess;
 use serde::de::SeqAccess;
 use serde::de::VariantAccess;
@@ -612,6 +613,22 @@ impl<'a, 'de> VariantAccess<'de> for &'a mut Decoder<'de> {
         V: serde::de::Visitor<'de>,
     {
         self.deserialize_map(visitor)
+    }
+}
+
+impl<'a, 'de> EnumAccess<'de> for &'a mut Decoder<'de> {
+    type Error = Error;
+
+    type Variant = Self;
+
+    fn variant_seed<V>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        Ok((seed.deserialize(&mut *self)?, self))
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -979,6 +979,19 @@ mod test {
     }
 
     #[test]
+    fn deserialize_tuple_variant() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        enum Enum {
+            Foo(i32, i32),
+            Bar(char, bool),
+            Baz(String, u8),
+        }
+        test_decode!(b"d3:Fooli50ei90eee", Ok(Enum::Foo(50, 90)));
+        test_decode!(b"d3:Barl1:ai1eee", Ok(Enum::Bar('a', true)));
+        test_decode!(b"d3:Bazl3:fooi255eee", Ok(Enum::Baz("foo".into(), 255)));
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {

--- a/src/de.rs
+++ b/src/de.rs
@@ -992,6 +992,18 @@ mod test {
     }
 
     #[test]
+    fn deserialize_struct_variant() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        enum Enum {
+            Foo { a: char, b: char },
+        }
+        test_decode!(
+            b"d3:Food1:a1:z1:b1:yee",
+            Ok(Enum::Foo { a: 'z', b: 'y' })
+        );
+    }
+
+    #[test]
     fn deserialize_simple_struct() {
         #[derive(Debug, PartialEq, Deserialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -278,13 +278,18 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
-        _: &T,
+        variant: &'static str,
+        value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: serde::Serialize,
     {
-        Ok(())
+        self.tag(DICT_START)?;
+
+        self.serialize_str(variant)?;
+        value.serialize(&mut *self)?;
+
+        self.tag(TYPE_END)
     }
 
     fn serialize_seq(

--- a/src/en.rs
+++ b/src/en.rs
@@ -449,7 +449,13 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.en.tag(TYPE_END)
+        // A tuple variant is serialized as a dictionary with the variant's name mapping to a list of values.
+        // We need to write the 'TYPE_END' **twice**, otherwise the outer dictionary won't be closed.
+        //
+        // If we only write it **once**, then, for example:
+        //
+        // 'Enum::Foo(1, 2, 3)' will be encoded as 'd3:Fooli1ei2ei3ee' - so we need an additional end denotation.
+        self.en.write(&[TYPE_END, TYPE_END])
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -258,9 +258,9 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
+        variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Ok(())
+        self.serialize_str(variant)
     }
 
     fn serialize_newtype_struct<T: ?Sized>(

--- a/src/en.rs
+++ b/src/en.rs
@@ -995,6 +995,15 @@ mod test {
     }
 
     #[test]
+    fn serialize_struct_variant() {
+        #[derive(Debug, PartialEq, Serialize)]
+        enum Enum {
+            Foo { a: char, b: char },
+        }
+        test_encode!(Enum::Foo { a: 'z', b: 'y' }, b"d3:Food1:a1:z1:b1:yee");
+    }
+
+    #[test]
     fn serialize_simple_struct() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -351,9 +351,11 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
+        variant: &'static str,
         _: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.tag(DICT_START)?;
+        self.serialize_str(variant)?;
         self.tag(DICT_START)?;
         Ok(MapEncoder::new(self))
     }

--- a/src/en.rs
+++ b/src/en.rs
@@ -979,6 +979,19 @@ mod test {
     }
 
     #[test]
+    fn serialize_tuple_variant() {
+        #[derive(Debug, PartialEq, Serialize)]
+        enum Enum {
+            Foo(i32, i32),
+            Bar(char, bool),
+            Baz(String, u8),
+        }
+        test_encode!(Enum::Foo(50, 90), b"d3:Fooli50ei90eee");
+        test_encode!(Enum::Bar('a', true), b"d3:Barl1:ai1eee");
+        test_encode!(Enum::Baz("foo".into(), 255), b"d3:Bazl3:fooi255eee");
+    }
+
+    #[test]
     fn serialize_simple_struct() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -958,6 +958,19 @@ mod test {
     }
 
     #[test]
+    fn serialize_newtype_variant() {
+        #[derive(Debug, PartialEq, Serialize)]
+        enum Enum {
+            Foo(i32),
+            Bar(String),
+            Baz(bool),
+        }
+        test_encode!(Enum::Foo(50), b"d3:Fooi50ee");
+        test_encode!(Enum::Bar("foo".into()), b"d3:Bar3:fooe");
+        test_encode!(Enum::Baz(false), b"d3:Bazi0ee");
+    }
+
+    #[test]
     fn serialize_simple_struct() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -940,6 +940,19 @@ mod test {
     }
 
     #[test]
+    fn serialize_unit_variant() {
+        #[derive(Debug, PartialEq, Serialize)]
+        enum Enum {
+            Foo,
+            Bar,
+            Baz,
+        }
+        test_encode!(Enum::Foo, b"3:Foo");
+        test_encode!(Enum::Bar, b"3:Bar");
+        test_encode!(Enum::Baz, b"3:Baz");
+    }
+
+    #[test]
     fn serialize_simple_struct() {
         #[derive(Debug, PartialEq, Serialize)]
         struct Person {

--- a/src/en.rs
+++ b/src/en.rs
@@ -582,7 +582,8 @@ impl<'a, W: Write> SerializeStructVariant for MapEncoder<'a, W> {
             self.encoder.serialize_bytes(&key)?;
             self.encoder.write(&val)?;
         }
-        self.encoder.tag(TYPE_END)
+        // Note that we need to write the 'TYPE_END' **twice**, otherwise the outer dictionary won't have a closing delimiter.
+        self.encoder.write(&[TYPE_END, TYPE_END])
     }
 }
 

--- a/src/en.rs
+++ b/src/en.rs
@@ -321,9 +321,11 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
+        variant: &'static str,
         _: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.tag(DICT_START)?;
+        self.serialize_str(variant)?;
         self.tag(LIST_START)?;
         Ok(SeqEncoder::new(self))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,30 @@ mod test {
     }
 
     #[test]
+    fn encode_and_decode_nested_enum() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Player {
+            name: String,
+            class: Class,
+        }
+
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Class {
+            Wizard,
+            Fighter,
+        }
+
+        test_bende!(
+            Player,
+            Player { name: "Gandalf".into(), class: Class::Wizard }
+        );
+        test_bende!(
+            Player,
+            Player { name: "Gimly".into(), class: Class::Fighter }
+        );
+    }
+
+    #[test]
     fn encode_and_decode_nested_struct() {
         #[derive(Debug, PartialEq, Serialize, Deserialize)]
         struct Armory {


### PR DESCRIPTION
This PR introduces encoding and decoding support for `enum` types and their variants.

## Implementation

Consider this enum:

```rust
enum Enum {
    Unit,
    NewType(i32),
    Tuple(i32, i32),
    Struct { a: i32, b: i32 }
}
```

Each variant is encoded as such:

- `Enum::Unit` => `4:Unit`.
- `Enum::NewType(50)` => `d 7:NewType i50e e`.
- `Enum::Tuple(25, 50)` => `d  5:Tuple l i25e i50e e e`
- `Enum::Struct { a: 25, b: 50 }` => `d 6:Struct d 1:a i25e 1:b i50e e e`

**Note** that I only added whitespace to the examples above so they are more readable.

I believe these changes are **backwards-compatible**, since no items were added or removed from the API. Because of this, I've bumped the package version to `0.5.4` and updated the readme accordingly.

Upon a successful merge, this PR closes #2.