### PR TITLE
Docs/hide encoder types

### DIFF
--- a/src/en.rs
+++ b/src/en.rs
@@ -362,8 +362,6 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
 }
 
 /// An encoder used to encode the values in a sequence.
-///
-/// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct SeqEncoder<'a, W> {

--- a/src/en.rs
+++ b/src/en.rs
@@ -364,6 +364,7 @@ impl<'a, W: Write> Serializer for &'a mut Encoder<W> {
 /// An encoder used to encode the values in a sequence.
 ///
 /// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct SeqEncoder<'a, W> {
     en: &'a mut Encoder<W>,

--- a/src/en.rs
+++ b/src/en.rs
@@ -466,6 +466,7 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
 /// An encoder used to store and **sort** map or struct entries **before** encoding them.
 ///
 /// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct MapEncoder<'a, W> {
     encoder: &'a mut Encoder<W>,

--- a/src/en.rs
+++ b/src/en.rs
@@ -464,8 +464,6 @@ impl<'a, W: Write> SerializeTupleVariant for SeqEncoder<'a, W> {
 }
 
 /// An encoder used to store and **sort** map or struct entries **before** encoding them.
-///
-/// **Note** that this type cannot be constructed from outside this crate, and is only public because of the way the library's serialization is implemented.
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct MapEncoder<'a, W> {


### PR DESCRIPTION
I've only just remembered that rust has a special `#[doc(hidden)]` attribute you can use to hide items from documentation. I've added it to both the `SeqEncoder` and `MapEncoder` types and removed the note saying that these types can't be constructed outside the crate.

This does not change any behavior so I did not bump the package version.